### PR TITLE
Fix saucelabs link

### DIFF
--- a/_posts/2016-12-29-getting-start-remote-browser-test.md
+++ b/_posts/2016-12-29-getting-start-remote-browser-test.md
@@ -20,7 +20,7 @@ Don't have a desired browser in your local? No problem, _Testarmada_ has you cov
 {:.table.table-condensed.table-hover}
 | Name | Latest Version | Purpose |
 |:----------|:--------|:----------|
-| [magellan-saucelabs-executor](https://github.com/TestArmada/magellan-local-executor) | ^3.0.0 | Magellan executor to drive test on [Saucelabs](https://saucelabs.com/) |
+| [magellan-saucelabs-executor](https://github.com/TestArmada/magellan-saucelabs-executor) | ^3.0.0 | Magellan executor to drive test on [Saucelabs](https://saucelabs.com/) |
 | [magellan-browserstack-executor](https://github.com/TestArmada/magellan-browserstack-executor) | ^1.0.0 | Magellan executor to drive test on [Browserstack](https://www.browserstack.com/) |
 | [magellan-testobject-executor](https://github.com/TestArmada/magellan-testobject-executor) | ^1.0.0 | Magellan executor to drive test on [TestObject](https://testobject.com/) |
 | [magellan-seleniumgrid-executor](https://github.com/TestArmada/magellan-seleniumgrid-executor) | ^1.0.0 | Magellan executor to drive test in selenium grid |

--- a/index.md.bak
+++ b/index.md.bak
@@ -43,7 +43,7 @@ Magellan also support running test remotely via executor. Following executors ar
 | Name | Purpose |
 |:----------|:----------|
 | [magellan-local-executor](https://github.com/TestArmada/magellan-local-executor) | Magellan executor to drive test locally |
-| [magellan-saucelabs-executor](https://github.com/TestArmada/magellan-local-executor) | Magellan executor to drive test on [Saucelabs](https://saucelabs.com/) |
+| [magellan-saucelabs-executor](https://github.com/TestArmada/magellan-saucelabs-executor) | Magellan executor to drive test on [Saucelabs](https://saucelabs.com/) |
 | [magellan-browserstack-executor](https://github.com/TestArmada/magellan-browserstack-executor) | Magellan executor to drive test on [Browserstack](https://www.browserstack.com/) |
 | [magellan-testobject-executor](https://github.com/TestArmada/magellan-testobject-executor) | Magellan executor to drive test on [TestObject](https://testobject.com/) |
 | [magellan-seleniumgrid-executor](https://github.com/TestArmada/magellan-seleniumgrid-executor) | Magellan executor to drive test in selenium grid |


### PR DESCRIPTION
Fixes a typo on http://testarmada.io/#enableAnExecutor in the executor grid above that Enable an Executor heading.